### PR TITLE
Change available modes for camera (VISCOM)

### DIFF
--- a/addons/shared/functions/mission_defaults/fn_placeDefaultModules.sqf
+++ b/addons/shared/functions/mission_defaults/fn_placeDefaultModules.sqf
@@ -90,7 +90,8 @@ private _modules = [
     ]],
     ["ACEX_ModuleSitting"],
     ["ace_spectator_moduleSettings", [
-        ["ace_spectator_moduleSettings_sidesFilter", 3]
+        ["ace_spectator_moduleSettings_sidesFilter", 3],
+        ["ace_spectator_moduleSettings_cameraModes",1]
     ]],
     ["ace_weather_ModuleSettings", [
         ["ace_weather_ModuleSettings_enableServerController", false],


### PR DESCRIPTION
Free camera option is removed.
Only spectators should have free camera, which is set by a BIS function and not ACE